### PR TITLE
force set wait_for_build_beta_detail_processing to false

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -129,7 +129,7 @@ module Pilot
         return_when_build_appears: return_when_build_appears,
         return_spaceship_testflight_build: false,
         select_latest: config[:distribute_only],
-        wait_for_build_beta_detail_processing: true
+        wait_for_build_beta_detail_processing: false
       )
 
       unless latest_build.app_version == app_version && latest_build.version == app_build


### PR DESCRIPTION
In this PR we are force setting `wait_for_build_beta_detail_processing ` to false , so that when we pass chagelog while uploading to TestFlight the process won't wait for the build to complete process.

Currently there is an issue with appstore connect api , which causes the fastlane hanging in CI machine.

This is a workaround until Fastlane / Apple fixes their issue.

more details on the issue can be found here - https://github.com/fastlane/fastlane/issues/20645